### PR TITLE
Add practice space and game field AprilTagFieldLayouts

### DIFF
--- a/.OutlineViewer/outlineviewer.json
+++ b/.OutlineViewer/outlineviewer.json
@@ -1,0 +1,20 @@
+{
+  "Connections": {
+    "open": true
+  },
+  "NetworkTables Settings": {
+    "mode": "Client (NT4)",
+    "serverTeam": "localhost"
+  },
+  "transitory": {
+    "Poses": {
+      "open": true
+    },
+    "SmartDashboard": {
+      "Field": {
+        "open": true
+      },
+      "open": true
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1"
+    id "edu.wpi.first.GradleRIO" version "2023.2.1"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -45,24 +45,33 @@ public class Constants {
         public static final String cameraName = "visionCam";
         private static final double fieldLength = Units.inchesToMeters((54*12) + 3.25);
         private static final double fieldWidth = Units.inchesToMeters((26*12) + 3.5);
-        // TODO: measure origin to x translation
-        private static final Translation2d originToX = new Translation2d(4.5, 2);
+        
         // TODO: handle alliance switching
         public static final AprilTagFieldLayout tagLayout = new AprilTagFieldLayout(
             List.of(
-              new AprilTag(1, createTagPose(Units.inchesToMeters(440.625), Rotation2d.fromDegrees(63), Units.inchesToMeters(23.75))),//new Pose3d(0, 0, Units.inchesToMeters(23.75), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
-              new AprilTag(2, createTagPose(Units.inchesToMeters(370), Rotation2d.fromDegrees(123), Units.inchesToMeters(51.5))),
-              new AprilTag(3, createTagPose(Units.inchesToMeters(484.625), Rotation2d.fromDegrees(91), Units.inchesToMeters(26.25))),
-              new AprilTag(5, createTagPose(Units.inchesToMeters(271), Rotation2d.fromDegrees(33), Units.inchesToMeters(44))),
-              new AprilTag(6, createTagPose(Units.inchesToMeters(273), Rotation2d.fromDegrees(322), Units.inchesToMeters(57.0625))),
-              new AprilTag(7, createTagPose(Units.inchesToMeters(211.5), Rotation2d.fromDegrees(0), Units.inchesToMeters(43)))
+              new AprilTag(1, createTagPose(Units.inchesToMeters(440.625),  Rotation2d.fromDegrees(63), 23.75,  Rotation2d.fromDegrees(0))),
+              new AprilTag(2, createTagPose(Units.inchesToMeters(370),      Rotation2d.fromDegrees(123),51.5,   Rotation2d.fromDegrees(0))),
+              new AprilTag(3, createTagPose(Units.inchesToMeters(484.625),  Rotation2d.fromDegrees(91), 26.25,  Rotation2d.fromDegrees(0))),
+              new AprilTag(5, createTagPose(Units.inchesToMeters(271),      Rotation2d.fromDegrees(33), 44,     Rotation2d.fromDegrees(0))),
+              new AprilTag(6, createTagPose(Units.inchesToMeters(273),      Rotation2d.fromDegrees(322),57.0625,Rotation2d.fromDegrees(0))),
+              new AprilTag(7, createTagPose(Units.inchesToMeters(211.5),    Rotation2d.fromDegrees(0),  43,     Rotation2d.fromDegrees(0)))
             ), VisionConstants.fieldLength, VisionConstants.fieldWidth
         );
 
         // TODO: fill out robotToCamera transform once robot is designed
         public static final Transform3d robotToCamera = new Transform3d();
 
-        private static Pose3d createTagPose(double distanceMeters, Rotation2d measuredAngle, double heightMeters) {
+        // TODO: measure origin to x translation
+        private static final Translation2d originToX = new Translation2d(0, new Rotation2d(0));
+
+        /**
+         * Given measured distance, angle, and orientation from a predefined measurement point in a WNU coordinate system, determine the 3d pose in the WPILib field coordinate system
+         * @param distanceInches Hypotenuse distance from the measurement point to the tag's 2d location in inches
+         * @param measuredAngle WNU angle to the tag, measured at the measurement point
+         * @param heightInches Height of the tag centerpoint above the ground in inches
+         * @param tagRotation Angle the tag is facing in the XY plane (i.e. a rotation around the Z axis) in the field coordinate system (0 = towards far wall, 90 = towards archery windows, 180 = towards janitor room, 270 = towards bleachers)
+         */
+        private static Pose3d createTagPose(double distanceInches, Rotation2d measuredAngle, double heightInches, Rotation2d tagRotation) {
             // Step 1.start at origin
             Pose2d originPose = new Pose2d();
             // Step 2.  translate to measurement point
@@ -71,9 +80,9 @@ public class Constants {
             // Step 3. rotate tag angle to new coord system
             Rotation2d angleToTag = Rotation2d.fromDegrees((measuredAngle.getDegrees() - 90) * -1);
             // Step 4. find and apply translation to tag (on ground)
-            Pose2d tagPose = center.transformBy(new Transform2d(new Translation2d(distanceMeters, angleToTag), new Rotation2d()));
-            // Step 5. move pose up to tag height
-            Pose3d tagPose3d = new Pose3d(tagPose.getX(), tagPose.getY(), heightMeters, new Rotation3d(VecBuilder.fill(0, 1, 0), Units.degreesToRadians(-90)));
+            Pose2d tagPose = center.transformBy(new Transform2d(new Translation2d(Units.inchesToMeters(distanceInches), angleToTag), new Rotation2d()));
+            // Step 5. move pose up to tag height and apply orientation
+            Pose3d tagPose3d = new Pose3d(tagPose.getX(), tagPose.getY(), Units.inchesToMeters(heightInches), new Rotation3d(VecBuilder.fill(0, 0, 1), tagRotation.getRadians()));
             // Done!
             return tagPose3d;
         }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import edu.wpi.first.apriltag.AprilTag;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -45,7 +46,7 @@ public class Constants {
         private static final double fieldLength = Units.inchesToMeters((54*12) + 3.25);
         private static final double fieldWidth = Units.inchesToMeters((26*12) + 3.5);
         // TODO: measure origin to x translation
-        private static final Translation2d originToX = new Translation2d(0, 0);
+        private static final Translation2d originToX = new Translation2d(4.5, 2);
         // TODO: handle alliance switching
         public static final AprilTagFieldLayout tagLayout = new AprilTagFieldLayout(
             List.of(
@@ -53,7 +54,7 @@ public class Constants {
               new AprilTag(2, createTagPose(Units.inchesToMeters(370), Rotation2d.fromDegrees(123), Units.inchesToMeters(51.5))),
               new AprilTag(3, createTagPose(Units.inchesToMeters(484.625), Rotation2d.fromDegrees(91), Units.inchesToMeters(26.25))),
               new AprilTag(5, createTagPose(Units.inchesToMeters(271), Rotation2d.fromDegrees(33), Units.inchesToMeters(44))),
-              new AprilTag(6, createTagPose(Units.inchesToMeters(273), Rotation2d.fromDegrees(302), Units.inchesToMeters(57.0625))),
+              new AprilTag(6, createTagPose(Units.inchesToMeters(273), Rotation2d.fromDegrees(322), Units.inchesToMeters(57.0625))),
               new AprilTag(7, createTagPose(Units.inchesToMeters(211.5), Rotation2d.fromDegrees(0), Units.inchesToMeters(43)))
             ), VisionConstants.fieldLength, VisionConstants.fieldWidth
         );
@@ -72,7 +73,7 @@ public class Constants {
             // Step 4. find and apply translation to tag (on ground)
             Pose2d tagPose = center.transformBy(new Transform2d(new Translation2d(distanceMeters, angleToTag), new Rotation2d()));
             // Step 5. move pose up to tag height
-            Pose3d tagPose3d = new Pose3d(tagPose.getX(), tagPose.getY(), heightMeters, new Rotation3d());
+            Pose3d tagPose3d = new Pose3d(tagPose.getX(), tagPose.getY(), heightMeters, new Rotation3d(VecBuilder.fill(0, 1, 0), Units.degreesToRadians(-90)));
             // Done!
             return tagPose3d;
         }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import edu.wpi.first.apriltag.AprilTag;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
-import edu.wpi.first.math.VecBuilder;
-import edu.wpi.first.math.geometry.CoordinateAxis;
-import edu.wpi.first.math.geometry.CoordinateSystem;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -14,7 +11,6 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 
 public class Constants {
@@ -46,10 +42,11 @@ public class Constants {
     public static final class VisionConstants {
         // TODO: set camera name based on the actual camera name
         public static final String cameraName = "visionCam";
-        private static final double fieldLength = Units.feetToMeters(54);
-        private static final double fieldWidth = Units.feetToMeters(26);
+        private static final double fieldLength = Units.inchesToMeters((54*12) + 3.25);
+        private static final double fieldWidth = Units.inchesToMeters((26*12) + 3.5);
+        // TODO: measure origin to x translation
         private static final Translation2d originToX = new Translation2d(0, 0);
-        // TODO: find a way to reduce hypotenuse to x and y coords
+        // TODO: handle alliance switching
         public static final AprilTagFieldLayout tagLayout = new AprilTagFieldLayout(
             List.of(
               new AprilTag(1, createTagPose(Units.inchesToMeters(440.625), Rotation2d.fromDegrees(63), Units.inchesToMeters(23.75))),//new Pose3d(0, 0, Units.inchesToMeters(23.75), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
@@ -62,10 +59,7 @@ public class Constants {
         );
 
         // TODO: fill out robotToCamera transform once robot is designed
-        public static final Transform3d robotToCamera = new Transform3d(
-            new Translation3d(0, null), 
-            new Rotation3d(0, 0, 0)
-        );
+        public static final Transform3d robotToCamera = new Transform3d();
 
         private static Pose3d createTagPose(double distanceMeters, Rotation2d measuredAngle, double heightMeters) {
             // Step 1.start at origin
@@ -75,10 +69,11 @@ public class Constants {
             Pose2d center = originPose.transformBy(new Transform2d(originToX, new Rotation2d()));
             // Step 3. rotate tag angle to new coord system
             Rotation2d angleToTag = Rotation2d.fromDegrees((measuredAngle.getDegrees() - 90) * -1);
-            // Step 4. find and apply translation to tag
+            // Step 4. find and apply translation to tag (on ground)
             Pose2d tagPose = center.transformBy(new Transform2d(new Translation2d(distanceMeters, angleToTag), new Rotation2d()));
-            // move up 
+            // Step 5. move pose up to tag height
             Pose3d tagPose3d = new Pose3d(tagPose.getX(), tagPose.getY(), heightMeters, new Rotation3d());
+            // Done!
             return tagPose3d;
         }
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -42,18 +42,17 @@ public class Constants {
         public static final String cameraName = "visionCam";
         private static final double fieldLength = Units.feetToMeters(54);
         private static final double fieldWidth = Units.feetToMeters(26);
-        // TODO: fill out field layout with what we set up in the practice area
+        // TODO: find a way to reduce hypotenuse to x and y coords
         public static final AprilTagFieldLayout tagLayout = new AprilTagFieldLayout(
             List.of(
-              new AprilTag(0, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(1, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(2, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(3, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(4, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(5, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(6, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(7, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0))),
-              new AprilTag(8, new Pose3d(0, 0, 0, new Rotation3d(VecBuilder.fill(0, 0, 0), 0)))
+              new AprilTag(1, new Pose3d(0, 0, Units.inchesToMeters(23.75), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(2, new Pose3d(0, 0, Units.inchesToMeters(51.5), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(3, new Pose3d(0, 0, Units.inchesToMeters(26.25), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(4, new Pose3d(0, 0, Units.inchesToMeters(52.75), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(5, new Pose3d(0, 0, Units.inchesToMeters(44), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(6, new Pose3d(0, 0, Units.inchesToMeters(57.0625), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(7, new Pose3d(0, 0, Units.inchesToMeters(43), new Rotation3d(VecBuilder.fill(0, 0, 1), 0))),
+              new AprilTag(8, new Pose3d(0, 0, Units.inchesToMeters(58.875), new Rotation3d(VecBuilder.fill(0, 0, 1), 0)))
             ), VisionConstants.fieldLength, VisionConstants.fieldWidth
         );
         // TODO: fill out robotToCamera transform once robot is designed

--- a/src/main/java/frc/robot/Subsystems/Drive.java
+++ b/src/main/java/frc/robot/Subsystems/Drive.java
@@ -6,11 +6,12 @@ package frc.robot.Subsystems;
 
 import java.util.function.Supplier;
 
+import org.photonvision.EstimatedRobotPose;
+
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.kauailabs.navx.frc.AHRS;
 
 
-import edu.wpi.first.math.Pair;
 import edu.wpi.first.math.estimator.DifferentialDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -43,10 +44,10 @@ public class Drive extends SubsystemBase {
   DifferentialDrive diffDrive = new DifferentialDrive(LeftMCG, RightMCG);
 
   DifferentialDrivePoseEstimator poseEstimator = new DifferentialDrivePoseEstimator(new DifferentialDriveKinematics(DriveConstants.trackwidthMeters), new Rotation2d(), getLeftDistanceMeters(), getRightDistanceMeters(), new Pose2d());
-  Supplier<Pair<Pose2d,Double>> visionPose;
+  Supplier<EstimatedRobotPose> visionPose;
   DoubleSolenoid shifter = new DoubleSolenoid(PneumaticsModuleType.REVPH, DriveConstants.Shifter_Forward_Channel, DriveConstants.Shifter_Reverse_Channel);
 
-  public Drive(Supplier<Pair<Pose2d, Double>> visionPoseSupplier) {
+  public Drive(Supplier<EstimatedRobotPose> visionPoseSupplier) {
 
     Left_Front.configFactoryDefault();
     Right_Front.configFactoryDefault();
@@ -102,10 +103,10 @@ public class Drive extends SubsystemBase {
   public void periodic() {
     poseEstimator.update(gyro.getRotation2d(), getRightDistanceMeters(), getLeftDistanceMeters());
     // if we see targets
-    if (visionPose.get().getFirst() != null) {
+    if (visionPose.get().timestampSeconds > 0) {
       // if the pose is reasonably close
-      if (visionPose.get().getFirst().getTranslation().getDistance(poseEstimator.getEstimatedPosition().getTranslation()) < 1.5) {
-        poseEstimator.addVisionMeasurement(visionPose.get().getFirst(), visionPose.get().getSecond());
+      if (visionPose.get().estimatedPose.toPose2d().getTranslation().getDistance(poseEstimator.getEstimatedPosition().getTranslation()) < 1.5) {
+        poseEstimator.addVisionMeasurement(visionPose.get().estimatedPose.toPose2d(), visionPose.get().timestampSeconds);
       }
     }
 

--- a/src/main/java/frc/robot/Subsystems/Vision.java
+++ b/src/main/java/frc/robot/Subsystems/Vision.java
@@ -14,6 +14,7 @@ import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VisionConstants;
+import frc.robot.Utility.NTHelper;
 
 public class Vision extends SubsystemBase {
   PhotonCamera camera;
@@ -24,6 +25,7 @@ public class Vision extends SubsystemBase {
   public Vision() {
     camera = new PhotonCamera(VisionConstants.cameraName);
     poseEstimator = new PhotonPoseEstimator(VisionConstants.tagLayout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, camera, VisionConstants.robotToCamera);
+    NTHelper.sendTagLayout(VisionConstants.tagLayout);
   }
 
   /**

--- a/src/main/java/frc/robot/Subsystems/Vision.java
+++ b/src/main/java/frc/robot/Subsystems/Vision.java
@@ -11,6 +11,7 @@ import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VisionConstants;
@@ -24,6 +25,13 @@ public class Vision extends SubsystemBase {
 
   public Vision() {
     camera = new PhotonCamera(VisionConstants.cameraName);
+    //AprilTagFieldLayout layout = new AprilTagFieldLayout(List.of(), 0, 0);
+    //try {
+    //  layout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2023ChargedUp.m_resourceFile);
+    //} catch (IOException ioe) {
+    //  DriverStation.reportError(ioe.getMessage(), ioe.getStackTrace());
+    //}
+    //poseEstimator = new PhotonPoseEstimator(layout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, camera, VisionConstants.robotToCamera);
     poseEstimator = new PhotonPoseEstimator(VisionConstants.tagLayout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, camera, VisionConstants.robotToCamera);
     NTHelper.sendTagLayout(VisionConstants.tagLayout);
   }
@@ -35,6 +43,10 @@ public class Vision extends SubsystemBase {
    */
   public EstimatedRobotPose getCurrentPoseEstimate() {
     return currentFieldPose;
+  }
+
+  public void setReferencePose(Pose2d pose) {
+    poseEstimator.setReferencePose(pose);
   }
   
   @Override

--- a/src/main/java/frc/robot/Subsystems/Vision.java
+++ b/src/main/java/frc/robot/Subsystems/Vision.java
@@ -4,47 +4,40 @@
 
 package frc.robot.Subsystems;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
-import org.photonvision.RobotPoseEstimator;
-import org.photonvision.RobotPoseEstimator.PoseStrategy;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
-import edu.wpi.first.math.Pair;
-import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.wpilibj.Timer;
-
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VisionConstants;
 
 public class Vision extends SubsystemBase {
   PhotonCamera camera;
-  RobotPoseEstimator poseEstimator;
-  Pair<Pose2d, Double> currentFieldPose;
+  PhotonPoseEstimator poseEstimator;
+  EstimatedRobotPose currentFieldPose;
   /** Creates a new Vision. */
 
   public Vision() {
     camera = new PhotonCamera(VisionConstants.cameraName);
-    poseEstimator = new RobotPoseEstimator(VisionConstants.tagLayout, PoseStrategy.AVERAGE_BEST_TARGETS, List.of(
-      new Pair<PhotonCamera, Transform3d>(camera, VisionConstants.robotToCamera)
-      ));
+    poseEstimator = new PhotonPoseEstimator(VisionConstants.tagLayout, PoseStrategy.CLOSEST_TO_REFERENCE_POSE, camera, VisionConstants.robotToCamera);
   }
 
-  public Pair<Pose2d,Double> getCurrentPoseEstimate() {
+  public EstimatedRobotPose getCurrentPoseEstimate() {
     return currentFieldPose;
   }
   
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
-    Optional<Pair<Pose3d,Double>> poseResult = poseEstimator.update();
+    Optional<EstimatedRobotPose> poseResult = poseEstimator.update();
     if (poseResult.isPresent()) {
-      currentFieldPose = new Pair<Pose2d, Double>(poseResult.get().getFirst().toPose2d(), Timer.getFPGATimestamp() - poseResult.get().getSecond());
+      currentFieldPose = poseResult.get();
     } else {
-      currentFieldPose = new Pair<Pose2d,Double>(null, 0.0);
+      currentFieldPose = new EstimatedRobotPose(new Pose3d(), -1);
     }
   }
 }

--- a/src/main/java/frc/robot/Utility/NTHelper.java
+++ b/src/main/java/frc/robot/Utility/NTHelper.java
@@ -1,0 +1,38 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.Utility;
+
+import java.util.ArrayList;
+
+import edu.wpi.first.apriltag.AprilTag;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.networktables.DoubleArrayPublisher;
+import edu.wpi.first.networktables.IntegerArrayPublisher;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+/** Helper functions for using NT4 */
+public class NTHelper {
+    private static NetworkTable poseTable = NetworkTableInstance.getDefault().getTable("Poses");
+    public static void sendTagLayout(AprilTagFieldLayout tags) {
+        for (AprilTag tag : tags.getTags()) {
+            ArrayList<Double> tagPropertyList = new ArrayList<>();
+            tagPropertyList.add(tag.pose.getX());
+            tagPropertyList.add(tag.pose.getY()); 
+            tagPropertyList.add(tag.pose.getZ());
+            tagPropertyList.add(tag.pose.getRotation().getQuaternion().getW());
+            tagPropertyList.add(tag.pose.getRotation().getQuaternion().getX());
+            tagPropertyList.add(tag.pose.getRotation().getQuaternion().getY());
+            tagPropertyList.add(tag.pose.getRotation().getQuaternion().getZ());
+            DoubleArrayPublisher tagPub = poseTable.getDoubleArrayTopic("AprilTag" + tag.ID).publish();
+            tagPub.getTopic().setRetained(true);
+            tagPub.set(tagPropertyList.stream().mapToDouble(Double::doubleValue).toArray());
+            tagPub.close();
+        }
+        IntegerArrayPublisher idPub = poseTable.getIntegerArrayTopic("AprilTag ID").publish();
+        idPub.getTopic().setRetained(true);
+        idPub.set(new long[] { 1, 2, 3, 5, 6, 7});
+        idPub.close();
+    }
+}

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2023.1.2",
+    "version": "dev-v2023.1.2-10-ga16ac4af",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004 ",
     "mavenUrls": [
         "https://maven.photonvision.org/repository/internal",
@@ -13,7 +13,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "PhotonLib-cpp",
-            "version": "v2023.1.2",
+            "version": "dev-v2023.1.2-10-ga16ac4af",
             "libName": "Photon",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -30,12 +30,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "PhotonLib-java",
-            "version": "v2023.1.2"
+            "version": "dev-v2023.1.2-10-ga16ac4af"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "PhotonTargeting-java",
-            "version": "v2023.1.2"
+            "version": "dev-v2023.1.2-10-ga16ac4af"
         }
     ]
 }


### PR DESCRIPTION
Changelog:

- Fills out AprilTagFieldLayout for our practice space
- Increases accuracy of field dimensions
- Updates WPILib to 2023.2.1
- Updates Vision system to use PhotonPoseEstimator/EstimatedRobotPose (will possibly need reconciling when master is merged up into the sim branch)
- PhotonLib version changed to dev build for new features (will need to update to 2023.2.1 once it is released in the coming days, that can be a separate PR)
- Publishes the AprilTagFieldLayout to NT so it is viewable in AdvantageScope 